### PR TITLE
Fix furrifier failing

### DIFF
--- a/FO4Edit/Edit Scripts/FFO_Furrifier.pas
+++ b/FO4Edit/Edit Scripts/FFO_Furrifier.pas
@@ -544,7 +544,7 @@ end;
 Procedure NPC_SetRace(raceIndex: integer);
 var
     race: IwbMainRecord;
-    raceFormID: integer;
+    raceFormID: cardinal;
     racename: string;
     skin: IwbMainRecord;
 begin


### PR DESCRIPTION
Fix invalid type conversion when furrifying with races with formIDs >= 0x80000000 (as in, from lite plugins or plugins of index >= 80) or  due to improperly using a signed 32-bit integer to store the race's formID